### PR TITLE
Fix KeyError for missing 'url' in yt_dlp entry when fetching by video_ids

### DIFF
--- a/ytfetcher/_youtube_dl.py
+++ b/ytfetcher/_youtube_dl.py
@@ -66,7 +66,7 @@ class BaseYoutubeDLFetcher(ABC):
                 video_id=entry["id"],
                 title=entry["title"],
                 description=entry["description"],
-                url=entry["url"] or f"https://youtube.com/watch?v={entry.get('id')}",
+                url=entry.get("url") or f"https://youtube.com/watch?v={entry.get('id')}",
                 duration=entry["duration"],
                 view_count=entry["view_count"],
                 thumbnails=entry["thumbnails"],


### PR DESCRIPTION
## Fix KeyError for missing 'url' in yt_dlp entry when fetching by video_ids

### Description

This PR fixes an issue where running the CLI with `from_video_ids` would fail with a `KeyError: 'url'` if the `yt_dlp` result for a video did not include a `url` key.

The `_to_snippets` method in `_youtube_dl.py` now uses `entry.get("url")` instead of `entry["url"]`, falling back to a constructed YouTube URL if the key is missing.

### Why

- The bug prevented CLI usage for individual video IDs, even though playlist and channel fetching worked.
- This change makes the CLI robust to missing fields in yt_dlp output.

### How to test

- Run `ytfetcher from_video_ids -f json -v <video_id>` and confirm it works without error.
- Confirm that playlist and channel fetching are unaffected.