### PR TITLE
Scope SQLite caching to transcripts only

### DIFF
--- a/tests/test_ytfetcher.py
+++ b/tests/test_ytfetcher.py
@@ -1,4 +1,5 @@
 import pytest
+import sqlite3
 from ytfetcher._core import YTFetcher
 from ytfetcher.models.channel import (
     ChannelData,
@@ -10,6 +11,7 @@ from ytfetcher.config.http_config import HTTPConfig
 from ytfetcher.config.fetch_config import FetchOptions
 from ytfetcher.exceptions import *
 from ytfetcher._transcript_fetcher import TranscriptFetcher
+from ytfetcher._youtube_dl import BaseYoutubeDLFetcher
 from youtube_transcript_api.proxies import ProxyConfig
 from ytfetcher.utils.headers import get_realistic_headers
 from unittest.mock import create_autospec, MagicMock
@@ -205,3 +207,44 @@ def test_proxy_config(mock_transcript_fetcher, mock_channel_fetcher_class):
     )
 
     assert fetcher.options.proxy_config is proxy_config_mock
+
+
+def test_transcripts_are_cached(tmp_path, sample_transcripts):
+    class DummyFetcher(BaseYoutubeDLFetcher):
+        def fetch(self) -> list[DLSnippet]:
+            return [
+                DLSnippet(
+                    video_id='id1',
+                    title='channelname1',
+                    description='description1',
+                )
+            ]
+
+    fetch_options = FetchOptions(cache_enabled=True, cache_path=str(tmp_path / "cache.db"))
+    fetcher = YTFetcher(youtube_dl_fetcher=DummyFetcher(), options=fetch_options)
+
+    mocked_fetch = MagicMock(
+        side_effect=[
+            [VideoTranscript(video_id='id1', transcripts=sample_transcripts)],
+            [VideoTranscript(video_id='id1', transcripts=sample_transcripts)],
+        ]
+    )
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(TranscriptFetcher, "fetch", mocked_fetch)
+
+        first_result = fetcher.fetch_transcripts()
+        second_result = fetcher.fetch_transcripts()
+
+    assert len(first_result) == 1
+    assert len(second_result) == 1
+    assert mocked_fetch.call_count == 1
+
+    with sqlite3.connect(str(tmp_path / "cache.db")) as conn:
+        table_names = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        }
+
+    assert "transcript_cache" in table_names
+    assert "metadata_cache" not in table_names

--- a/ytfetcher/_cli.py
+++ b/ytfetcher/_cli.py
@@ -71,7 +71,9 @@ class YTFetcherCLI:
                 proxy_config=ConfigBuilder.build_proxy_config(self.args),
                 languages=self.args.languages,
                 manually_created=self.args.manually_created,
-                filters=self._get_active_filters()
+                filters=self._get_active_filters(),
+                cache_enabled=self.args.cache,
+                cache_path=self.args.cache_path,
             ),
             **kwargs
         )
@@ -255,6 +257,10 @@ def _create_common_arguments(parser: ArgumentParser) -> None:
     net_group.add_argument("--webshare-proxy-password", default=None, type=str, help='Specify your Webshare "Proxy Password" found at https://dashboard.webshare.io/proxy/settings')
     net_group.add_argument("--http-proxy", default="", metavar="URL", help="Use the specified HTTP proxy.")
     net_group.add_argument("--https-proxy", default="", metavar="URL", help="Use the specified HTTPS proxy.")
+
+    cache_group = parser.add_argument_group("Cache Options")
+    cache_group.add_argument("--cache", action="store_true", help="Enable SQLite cache for transcripts.")
+    cache_group.add_argument("--cache-path", default=".ytfetcher_cache.sqlite3", help="Path to sqlite cache database.")
 
     output_group = parser.add_argument_group("Output Options")
     output_group.add_argument("--stdout", action="store_true", help="Dump data to console.")

--- a/ytfetcher/cache/__init__.py
+++ b/ytfetcher/cache/__init__.py
@@ -1,0 +1,3 @@
+from ytfetcher.cache.sqlite_cache import SQLiteCache
+
+__all__ = ["SQLiteCache"]

--- a/ytfetcher/cache/sqlite_cache.py
+++ b/ytfetcher/cache/sqlite_cache.py
@@ -1,0 +1,75 @@
+import sqlite3
+import json
+from pathlib import Path
+from ytfetcher.models.channel import VideoTranscript
+
+
+class SQLiteCache:
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def _initialize(self) -> None:
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS transcript_cache (
+                    video_id TEXT NOT NULL,
+                    cache_key TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (video_id, cache_key)
+                )
+                """
+            )
+
+    def get_transcripts(self, video_ids: list[str], cache_key: str) -> list[VideoTranscript]:
+        if not video_ids:
+            return []
+
+        placeholders = ",".join("?" for _ in video_ids)
+        query = (
+            f"SELECT payload FROM transcript_cache WHERE cache_key = ? "
+            f"AND video_id IN ({placeholders})"
+        )
+
+        with self._connect() as conn:
+            rows = conn.execute(query, [cache_key, *video_ids]).fetchall()
+
+        return [VideoTranscript.model_validate_json(payload) for (payload,) in rows]
+
+    def upsert_transcripts(self, transcripts: list[VideoTranscript], cache_key: str) -> None:
+        if not transcripts:
+            return
+
+        rows = [
+            (transcript.video_id, cache_key, transcript.model_dump_json())
+            for transcript in transcripts
+        ]
+
+        with self._connect() as conn:
+            conn.executemany(
+                """
+                INSERT INTO transcript_cache (video_id, cache_key, payload, updated_at)
+                VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+                ON CONFLICT(video_id, cache_key) DO UPDATE SET
+                    payload = excluded.payload,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                rows,
+            )
+
+    @staticmethod
+    def build_transcript_cache_key(languages: list[str], manually_created: bool) -> str:
+        return json.dumps(
+            {
+                "languages": languages,
+                "manually_created": manually_created,
+            },
+            sort_keys=True,
+        )

--- a/ytfetcher/config/fetch_config.py
+++ b/ytfetcher/config/fetch_config.py
@@ -11,3 +11,5 @@ class FetchOptions:
     languages: Iterable[str] = ("en", )
     manually_created: bool = False
     filters: list[Callable[[DLSnippet], bool]] | None = None
+    cache_enabled: bool = False
+    cache_path: str = ".ytfetcher_cache.sqlite3"


### PR DESCRIPTION
### Motivation
- Metadata already includes `video_id` and fetching it with `yt-dlp` is fast, so avoid caching metadata to reduce complexity and potential staleness. 
- Keep the optional SQLite cache but restrict it to transcripts only to improve performance for replayed transcript fetches. 

### Description
- Remove metadata cache schema and related read/write helpers and keep only transcript caching in `ytfetcher/cache/sqlite_cache.py` (cache keyed by `(video_id, cache_key)`).
- Simplify snippet flow in `YTFetcher` to always fetch metadata via `yt-dlp` by calling `self._youtube_dl.fetch()` in `_get_snippets`, while retaining transcript caching logic in `_get_transcripts` and initializing `SQLiteCache` only when `options.cache_enabled` is true. 
- Add `cache_enabled` and `cache_path` to `FetchOptions` and clarify the CLI option help to state `--cache` enables SQLite cache for transcripts only in `ytfetcher/_cli.py`.
- Update/extend the unit test `test_transcripts_are_cached` in `tests/test_ytfetcher.py` to assert the DB contains `transcript_cache` and does not contain `metadata_cache`.

### Testing
- Ran the test suite with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -p pytest_mock` which completed successfully with `88 passed`.
- The updated `test_transcripts_are_cached` passed and confirms transcript caching behavior and absence of a metadata cache table.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698769b7ebd0832684aaa8cd2a9b34c3)