### PR TITLE
Update tests for TranscriptFetchResult/FailedTranscript shape and cache API changes; add failed-transcript tests

### DIFF
--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,7 +1,15 @@
 import pytest
 from ytfetcher._core import YTFetcher, CommentFetcher
 from ytfetcher.config import FetchOptions
-from ytfetcher.models.channel import DLSnippet, VideoTranscript, Transcript, VideoComments, Comment
+from ytfetcher.models.channel import (
+    DLSnippet,
+    VideoTranscript,
+    Transcript,
+    VideoComments,
+    Comment,
+    FailedTranscript,
+    TranscriptFetchResult,
+)
 from ytfetcher._transcript_fetcher import TranscriptFetcher
 from pytest_mock import MockerFixture
 
@@ -43,7 +51,7 @@ def mock_dependencies(mocker: MockerFixture, bulk_snippets, bulk_transcripts_shu
     mocker.patch.object(
         TranscriptFetcher, 
         'fetch', 
-        return_value=bulk_transcripts_shuffled
+        return_value=TranscriptFetchResult(success=bulk_transcripts_shuffled, failed=[])
     )
 
 @pytest.fixture
@@ -103,7 +111,20 @@ def test_partial_data_failures(mocker: MockerFixture, initialized_fetcher):
         VideoComments(video_id='vid_2', comments=[Comment(id='c2', text='Comment 2')]),
     ]
 
-    mocker.patch.object(TranscriptFetcher, 'fetch', return_value=partial_transcripts)
+    mocker.patch.object(
+        TranscriptFetcher,
+        'fetch',
+        return_value=TranscriptFetchResult(
+            success=partial_transcripts,
+            failed=[
+                FailedTranscript(
+                    video_id="vid_2",
+                    reason="NoTranscriptFound",
+                    message=None,
+                )
+            ],
+        ),
+    )
     mocker.patch.object(CommentFetcher, 'fetch', return_value=partial_comments)
 
     results = initialized_fetcher.fetch_with_comments()
@@ -131,7 +152,11 @@ def test_ignores_ghost_data(mocker: MockerFixture, initialized_fetcher):
         VideoTranscript(video_id="vid_ghost", transcripts=[Transcript(text="Ghost Text", start=0, duration=1)]),
     ]
 
-    mocker.patch.object(TranscriptFetcher, 'fetch', return_value=weird_transcripts)
+    mocker.patch.object(
+        TranscriptFetcher,
+        'fetch',
+        return_value=TranscriptFetchResult(success=weird_transcripts, failed=[]),
+    )
 
     results = initialized_fetcher.fetch_youtube_data()
 
@@ -140,3 +165,31 @@ def test_ignores_ghost_data(mocker: MockerFixture, initialized_fetcher):
     ids = [r.video_id for r in results]
     assert "vid_ghost" not in ids
     assert "vid_1" in ids
+
+def test_records_failed_transcripts_on_fetch(mocker: MockerFixture, initialized_fetcher):
+    mocker.patch.object(
+        TranscriptFetcher,
+        "fetch",
+        return_value=TranscriptFetchResult(
+            success=[
+                VideoTranscript(
+                    video_id="vid_1",
+                    transcripts=[Transcript(text="Text 1", start=0, duration=1)],
+                )
+            ],
+            failed=[
+                FailedTranscript(
+                    video_id="vid_2",
+                    reason="NoTranscriptFound",
+                    message=None,
+                )
+            ],
+        ),
+    )
+
+    initialized_fetcher.fetch_transcripts()
+    failed = initialized_fetcher.get_failed_transcripts()
+
+    assert len(failed) == 1
+    assert failed[0].video_id == "vid_2"
+    assert failed[0].reason == "NoTranscriptFound"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,5 @@
 from ytfetcher import YTFetcher, DLSnippet, VideoTranscript
-from ytfetcher.models.channel import Transcript
+from ytfetcher.models.channel import Transcript, TranscriptFetchResult
 from ytfetcher.config import FetchOptions, HTTPConfig
 from ytfetcher._transcript_fetcher import TranscriptFetcher
 from ytfetcher.cache.sqlite_cache import SQLiteCache
@@ -39,8 +39,14 @@ def test_transcripts_are_cached(tmp_path, sample_transcripts):
 
     mocked_fetch = MagicMock(
         side_effect=[
-            [VideoTranscript(video_id='id1', transcripts=sample_transcripts)],
-            [VideoTranscript(video_id='id1', transcripts=sample_transcripts)],
+            TranscriptFetchResult(
+                success=[VideoTranscript(video_id='id1', transcripts=sample_transcripts)],
+                failed=[],
+            ),
+            TranscriptFetchResult(
+                success=[VideoTranscript(video_id='id1', transcripts=sample_transcripts)],
+                failed=[],
+            ),
         ]
     )
 
@@ -93,12 +99,15 @@ def test_custom_cache_path_is_used(tmp_path, sample_transcripts):
             TranscriptFetcher,
             "fetch",
             MagicMock(
-                return_value=[
-                    VideoTranscript(
-                        video_id="id1",
-                        transcripts=sample_transcripts,
-                    )
-                ]
+                return_value=TranscriptFetchResult(
+                    success=[
+                        VideoTranscript(
+                            video_id="id1",
+                            transcripts=sample_transcripts,
+                        )
+                    ],
+                    failed=[],
+                )
             ),
         )
 
@@ -143,12 +152,15 @@ def test_cache_clear_removes_all_rows(tmp_path, sample_transcripts):
             TranscriptFetcher,
             "fetch",
             MagicMock(
-                return_value=[
-                    VideoTranscript(
-                        video_id="id1",
-                        transcripts=sample_transcripts,
-                    )
-                ]
+                return_value=TranscriptFetchResult(
+                    success=[
+                        VideoTranscript(
+                            video_id="id1",
+                            transcripts=sample_transcripts,
+                        )
+                    ],
+                    failed=[],
+                )
             ),
         )
 
@@ -201,8 +213,9 @@ def test_ttl_does_not_remove_fresh_rows(tmp_path):
     removed = cache.purge_expired()
     assert removed == 0
 
-    rows = cache.get_transcripts(["fresh"], "k")
-    assert len(rows) == 1
+    successes, failures = cache.get_cached_states(["fresh"], "k")
+    assert len(successes) == 1
+    assert len(failures) == 0
 
 def test_ttl_zero_disables_expiration(tmp_path):
     cache = SQLiteCache(tmp_path, ttl=0)

--- a/tests/test_transcript_fetcher.py
+++ b/tests/test_transcript_fetcher.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest_mock import MockerFixture
 from youtube_transcript_api._errors import NoTranscriptFound
-from ytfetcher.models.channel import VideoTranscript, Transcript, FailedTranscript
+from ytfetcher.models.channel import VideoTranscript, Transcript, FailedTranscript, TranscriptFetchResult
 from ytfetcher._transcript_fetcher import TranscriptFetcher
 from ytfetcher.config.http_config import HTTPConfig
 from youtube_transcript_api.proxies import GenericProxyConfig
@@ -39,9 +39,11 @@ def test_fetch_method_returns_correct_data(mocker: MockerFixture, mock_video_ids
     
     results = fetcher.fetch()
 
-    assert isinstance(results[0], VideoTranscript)
-    assert results[0].transcripts[0].text == 'text1'
-    assert results[0].video_id == 'video_id'
+    assert isinstance(results, TranscriptFetchResult)
+    assert isinstance(results.success[0], VideoTranscript)
+    assert results.success[0].transcripts[0].text == 'text1'
+    assert results.success[0].video_id == 'video_id'
+    assert results.failed == []
 
 def test_fetch_single_returns_correct_data(mocker, mock_video_ids):
     fetcher = TranscriptFetcher(mock_video_ids)
@@ -82,7 +84,8 @@ def test_concurrent_fetching(mocker, mock_video_ids):
 
     results = fetcher.fetch()
 
-    assert len(results) == len(mock_video_ids)
+    assert len(results.success) == len(mock_video_ids)
+    assert results.failed == []
     assert mock_fetch_single.call_count == len(mock_video_ids)
 
 
@@ -207,7 +210,36 @@ def test_fetch_manual_transcript_no_transcript(mocker):
     result = fetcher._fetch_single(video_id)
 
     assert isinstance(result, FailedTranscript)
-    assert fetcher._failures["NoTranscriptFound"] == 1
+    assert result.video_id == video_id
+    assert result.reason == "NoTranscriptFound"
+    assert result.message is None
+
+def test_fetch_tracks_success_and_failed_transcripts(mocker):
+    fetcher = TranscriptFetcher(["ok_video", "bad_video"])
+
+    results_by_video = {
+        "ok_video": VideoTranscript(
+            video_id="ok_video",
+            transcripts=[Transcript(text="ok", start=0, duration=1)],
+        ),
+        "bad_video": FailedTranscript(
+            video_id="bad_video",
+            reason="NoTranscriptFound",
+            message=None,
+        ),
+    }
+
+    mocker.patch.object(
+        fetcher,
+        "_fetch_single",
+        side_effect=lambda video_id: results_by_video[video_id],
+    )
+
+    result = fetcher.fetch()
+
+    assert [entry.video_id for entry in result.success] == ["ok_video"]
+    assert [entry.video_id for entry in result.failed] == ["bad_video"]
+    assert result.failed[0].reason == "NoTranscriptFound"
 
 def test_fetch_first_available_transcript_empty(mocker):
     video_id = "abc"

--- a/tests/test_ytfetcher.py
+++ b/tests/test_ytfetcher.py
@@ -4,7 +4,8 @@ from ytfetcher.models.channel import (
     ChannelData,
     DLSnippet,
     Transcript,
-    VideoTranscript
+    VideoTranscript,
+    TranscriptFetchResult,
 )
 from ytfetcher.config.http_config import HTTPConfig
 from ytfetcher.config.fetch_config import FetchOptions
@@ -75,12 +76,19 @@ def mock_search_fetcher_class(mocker, sample_snippet):
 
 @pytest.fixture
 def mock_transcript_fetcher(mocker: MockerFixture, sample_transcripts):
-    mock_transcript_fetcher = mocker.patch.object(TranscriptFetcher, 'fetch', return_value=[
-        VideoTranscript(
-            video_id="id1",
-            transcripts=sample_transcripts,
-        )
-    ])
+    mock_transcript_fetcher = mocker.patch.object(
+        TranscriptFetcher,
+        'fetch',
+        return_value=TranscriptFetchResult(
+            success=[
+                VideoTranscript(
+                    video_id="id1",
+                    transcripts=sample_transcripts,
+                )
+            ],
+            failed=[],
+        ),
+    )
 
     return mock_transcript_fetcher
 


### PR DESCRIPTION
### Motivation
- The transcript fetcher was refactored to return a `TranscriptFetchResult` containing `success` and `failed` lists and to emit `FailedTranscript` entries for missing transcripts, and the cache API now exposes cached successes and failures separately, so tests needed updating to match the new shapes and behavior.

### Description
- Updated imports in tests to include `TranscriptFetchResult` and `FailedTranscript` where applicable. 
- Adjusted mocked `TranscriptFetcher.fetch` return values to use `TranscriptFetchResult(success=[...], failed=[...])` instead of plain lists. 
- Updated assertions to inspect `result.success` and `result.failed` and to validate failed transcript metadata. 
- Changed cache tests to use `get_cached_states` returning `(successes, failures)` and updated expectations accordingly. 
- Added tests `test_records_failed_transcripts_on_fetch` and `test_fetch_tracks_success_and_failed_transcripts` to verify failed-transcript recording and propagation.

### Testing
- Ran the modified unit tests in `tests/test_alignment.py`, `tests/test_cache.py`, `tests/test_transcript_fetcher.py`, and `tests/test_ytfetcher.py` with `pytest`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8085c218832687db83d945e2c897)